### PR TITLE
Changing VMName from literal declaration to variable

### DIFF
--- a/Update-VMGpuPartitionDriver.ps1
+++ b/Update-VMGpuPartitionDriver.ps1
@@ -67,7 +67,7 @@ foreach ($d in $drivers) {
 
 }
 
-$VM = Get-VM -VMName "GPUP"
+$VM = Get-VM -VMName $VMName
 $VHD = Get-VHD -VMId $VM.VMId
 
 If ($VM.state -eq "Running") {


### PR DESCRIPTION
The original version had the VM Name literally declared, so it would get stuck trying to shut down a VM that doesn't exist rather than the actual VM (Example of issue below).

![image](https://user-images.githubusercontent.com/79947287/142781154-7d19c7d7-dfd1-40da-8005-f678d7016e3b.png)