### PR TITLE
Fix NotSupportedException: Resolve multiple drive letter assignments and mount delays

### DIFF
--- a/Update-VMGpuPartitionDriver.ps1
+++ b/Update-VMGpuPartitionDriver.ps1
@@ -36,7 +36,17 @@ While ($VM.State -ne "Off") {
     }
 
 "Mounting Drive..."
-$DriveLetter = (Mount-VHD -Path $VHD.Path -PassThru | Get-Disk | Get-Partition | Get-Volume | Where-Object {$_.DriveLetter} | ForEach-Object DriveLetter)
+    $mnt = Mount-VHD -Path $VHD.Path -PassThru
+    Start-Sleep -Seconds 3
+    $disk = $mnt | Get-Disk
+    if ($disk.IsOffline) { Set-Disk -Number $disk.Number -IsOffline $false }
+    $part = $disk | Get-Partition | Sort-Object Size -Descending | Select-Object -First 1
+    if ($part.DriveLetter -notmatch '^[A-Z]$') {
+        $part | Add-PartitionAccessPath -AssignDriveLetter -ErrorAction SilentlyContinue | Out-Null
+        Start-Sleep -Seconds 3
+        $part = $disk | Get-Partition | Sort-Object Size -Descending | Select-Object -First 1
+    }
+    $DriveLetter = "$($part.DriveLetter):"
 
 "Copying GPU Files - this could take a while..."
 Add-VMGPUPartitionAdapterFiles -hostname $Hostname -DriveLetter $DriveLetter -GPUName $GPUName


### PR DESCRIPTION
### Describe the bug
When running `Update-VMGpuPartitionDriver.ps1` on modern Windows 11 environments with `automount` enabled, mounting the VM's VHDX often assigns drive letters to multiple partitions simultaneously (such as the OS partition and the Recovery partition).

Because the original code uses `ForEach-Object DriveLetter`, `$DriveLetter` receives an array (e.g., `"E", "F"`). When appending `:`, PowerShell concatenates the array with spaces, resulting in an invalid path format like `"E F:\windows\system32"`. This causes `Copy-Item` to crash completely with a `NotSupportedException`.
Additionally, there is a timing issue where the script might execute before Windows fully recognizes the file system, or the disk remains `Offline` depending on the SAN policy, causing the variable to be empty.

### Proposed Solution
I rewrote the mount and drive letter acquisition block to be foolproof:
1. Added a 3-second `Start-Sleep` immediately after `Mount-VHD` to allow the file system to initialize.
2. Added a check to force the disk `Online` if it mounts as offline.
3. Used `Sort-Object Size -Descending | Select-Object -First 1` to strictly pinpoint the primary OS partition, ignoring small recovery partitions.
4. If no drive letter is automatically assigned to the OS partition, it forces an assignment and retrieves it.
5. Ensured `$DriveLetter` is exactly one valid drive letter.

I have tested this patch extensively on my local Hyper-V environment (Win 11, RTX 4060 Ti) and it successfully transferred all driver files without any path formatting errors. I hope this helps others facing the same issue!